### PR TITLE
fix radium events

### DIFF
--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -42,11 +42,11 @@
     - id: MobMouseRemi
       prob: 0.001
     - id: MobJetpackMouseBrown
-      prob: 0.005
+      prob: 0.001
     - id: MobJetpackMouseGray
-      prob: 0.005
+      prob: 0.001
     - id: MobJetpackMouseWhite
-      prob: 0.005
+      prob: 0.001
     - id: MobClockworkMouse
       prob: 0.001
 #radium end

--- a/Resources/Prototypes/Radium/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Radium/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -3,12 +3,12 @@
   name: orange star
   description: Big fukin star
   components:
-  - type: AnnounceOnSpawn
-    message: orange-star-appeared
-    sender: chat-manager-sender-announcement
-    sound:
-      path: /Audio/Misc/bluealert.ogg
-    color: red
+  # - type: AnnounceOnSpawn
+  #   message: orange-star-appeared
+  #   sender: chat-manager-sender-announcement
+  #   sound:
+  #     path: /Audio/Misc/bluealert.ogg
+  #   color: red
   - type: Clickable
   - type: AmbientSound
     volume: -3
@@ -75,12 +75,12 @@
   id: RedStar
   name: red star
   components:
-  - type: AnnounceOnSpawn
-    message: red-star-appeared
-    sender: chat-manager-sender-announcement
-    sound:
-      path: /Audio/Misc/gamma.ogg
-    color: violet
+  # - type: AnnounceOnSpawn
+  #   message: red-star-appeared
+  #   sender: chat-manager-sender-announcement
+  #   sound:
+  #     path: /Audio/Misc/gamma.ogg
+  #   color: violet
   - type: PointLight
     color: "red"
     enabled: true

--- a/Resources/Prototypes/Radium/GameRules/events.yml
+++ b/Resources/Prototypes/Radium/GameRules/events.yml
@@ -87,7 +87,7 @@
   - type: StationEvent
     weight: 4.5
     earliestStart: 30
-    reoccurrenceDelay: 60
+    reoccurrenceDelay: 6000
     minimumPlayers: 5
     duration: null
     startAnnouncementColor: red
@@ -109,7 +109,7 @@
   - type: StationEvent
     weight: 1.5
     earliestStart: 60
-    reoccurrenceDelay: 70
+    reoccurrenceDelay: 7000
     minimumPlayers: 5
     duration: null
     startAnnouncementColor: violet

--- a/Resources/Prototypes/Radium/GameRules/events.yml
+++ b/Resources/Prototypes/Radium/GameRules/events.yml
@@ -85,11 +85,13 @@
   id: StarSpawn
   components:
   - type: StationEvent
-    weight: 6.5
-    earliestStart: 15
+    weight: 4.5
+    earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 5
     duration: null
+    startAnnouncementColor: red
+    startAnnouncement: orange-star-appeared
     startAudio:
       path: /Audio/Misc/bluealert.ogg
       params:
@@ -105,11 +107,13 @@
   id: RedStarSpawn
   components:
   - type: StationEvent
-    weight: 5.5
-    earliestStart: 30
+    weight: 1.5
+    earliestStart: 60
     reoccurrenceDelay: 70
-    minimumPlayers: 8
+    minimumPlayers: 5
     duration: null
+    startAnnouncementColor: violet
+    startAnnouncement: red-star-appeared
     startAudio:
       path: /Audio/Misc/gamma.ogg
       params:


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Меняет редкость ивентов и перемещает объявления в события.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Изменения в игровых правилах**
	- Уменьшена вероятность появления мышей с реактивным ранцем
	- Повышен минимальный порог игроков для события миграции короля крыс с 15 до 30
	- Добавлены новые события spawns: Changeling, Star и Red Star
	- Скорректированы параметры весов и времени начала событий Star и Red Star

- **Изменения в сущностях**
	- Удален компонент объявления при spawne для сущностей Orange Star и Red Star
<!-- end of auto-generated comment: release notes by coderabbit.ai -->