### PR TITLE
Tweak Ahelp & Ghost window size. Raise TTS volume multiplier.

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:cc="clr-namespace:Content.Client.Administration.UI.Bwoink"
-            SetSize="900 500"
+            SetSize="1200 500"
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >

--- a/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml
+++ b/Content.Client/Administration/UI/CustomControls/PlayerListControl.xaml
@@ -3,7 +3,7 @@
               Orientation="Vertical">
     <Control MinSize="0 5" />
     <LineEdit Name="FilterLineEdit"
-              MinSize="100 0"
+              MinSize="200 0"
               HorizontalExpand="True"
               PlaceHolder="{Loc player-list-filter}"/>
     <PanelContainer Name="BackgroundPanel"
@@ -13,6 +13,6 @@
                   Access="Public"
                   Toggle="True"
                   Group="True"
-                  MinSize="100 0"/>
+                  MinSize="200 0"/>
     </PanelContainer>
 </BoxContainer>

--- a/Content.Client/Audio/ContentAudioSystem.cs
+++ b/Content.Client/Audio/ContentAudioSystem.cs
@@ -29,7 +29,7 @@ public sealed partial class ContentAudioSystem : SharedContentAudioSystem
     public const float AmbientMusicMultiplier = 3f;
     public const float LobbyMultiplier = 3f;
     public const float InterfaceMultiplier = 2f;
-    public const float TtsMultiplier = 3f; // Corvax-TTS
+    public const float TtsMultiplier = 6f; // Corvax-TTS
 
     public override void Initialize()
     {

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
@@ -1,4 +1,4 @@
-<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc 'ghost-target-window-title'}" MinSize="550 450" SetSize="550 450">
+<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc 'ghost-target-window-title'}" MinSize="550 550" SetSize="550 550">
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.4">
         <Button Name="GhostnadoButton" Text="{Loc 'ghost-target-window-warp-to-most-followed'}" HorizontalAlignment="Center" Margin="0 4" />
         <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="0 4" />

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
@@ -1,4 +1,4 @@
-<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc 'ghost-target-window-title'}" MinSize="450 450" SetSize="450 450">
+<DefaultWindow xmlns="https://spacestation14.io" Title="{Loc 'ghost-target-window-title'}" MinSize="550 450" SetSize="550 450">
     <BoxContainer Orientation="Vertical" HorizontalExpand="True" SizeFlagsStretchRatio="0.4">
         <Button Name="GhostnadoButton" Text="{Loc 'ghost-target-window-warp-to-most-followed'}" HorizontalAlignment="Center" Margin="0 4" />
         <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="0 4" />

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -60,7 +60,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                     HorizontalAlignment = HAlignment.Center,
                     VerticalAlignment = VAlignment.Center,
                     SizeFlagsStretchRatio = 1,
-                    MinSize = new Vector2(340, 20),
+                    MinSize = new Vector2(440, 20),
                     ClipText = true,
                 };
 


### PR DESCRIPTION
## Описание PR
Окно ахелпа и телепорта призрака стало шире по умолчанию, тискать его каждый раз не очень удобно.
Ползунок ТТС стал в два раза чувствительнее.

## Почему / Баланс
Удобство?

## Медиа
![изображение](https://github.com/user-attachments/assets/d32d6f59-ffd8-4afe-b84c-1d29ea50c78d)
![изображение](https://github.com/user-attachments/assets/7cabd307-3c58-4c5e-b608-5089687624e8)

## Требования
- [X] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
<!--
:cl: freeze2222
- tweak: Expand ahelp window.
- tweak: Expand ghost warp window.
- tweak: Raise TTS volume multiplier to 6f.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые возможности**
	- Увеличен размер окон администратора и призрака для улучшения видимости элементов интерфейса.

- **Улучшения производительности**
	- Увеличен множитель громкости для текста-в-речь с 3 до 6 единиц.

- **Исправления пользовательского интерфейса**
	- Расширены минимальные размеры элементов управления в списке игроков.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->