### PR TITLE
Update launcher-connecting.ftl

### DIFF
--- a/Resources/Locale/ru-RU/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/ru-RU/launcher/launcher-connecting.ftl
@@ -1,6 +1,6 @@
 ### Connecting dialog when you start up the game
 
-connecting-title = Backmen Station 14
+connecting-title = Radium Station 14
 connecting-exit = Выйти
 connecting-retry = Повторить
 connecting-reconnect = Переподключиться
@@ -9,7 +9,7 @@ connecting-redial = Перезапустить
 connecting-redial-wait = Пожалуйста подождите: { TOSTRING($time, "G3") }
 connecting-in-progress = Подключение к серверу...
 connecting-disconnected = Отключён от сервера:
-connecting-tip = В космосе тебя никто не услышит.
+connecting-tip = Не будь мудаком.
 connecting-window-tip = Совет { $numberTip }
 connecting-version = версия 6.9
 connecting-fail-reason =


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Твик описания подключения.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Локализация**
	- Обновлено название лаунчера с "Backmen Station 14" на "Radium Station 14"
	- Изменен совет при подключении с "В космосе тебя никто не услышит." на "Не будь мудаком."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->