### PR TITLE
updated GhostReJoinSystem

### DIFF
--- a/Content.Server/Backmen/Ghost/GhostReJoinSystem.cs
+++ b/Content.Server/Backmen/Ghost/GhostReJoinSystem.cs
@@ -107,8 +107,7 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
         }
         var timeOffset = _gameTiming.CurTime - ent.Comp.TimeOfDeath;
         var timeLeft = _ghostRespawnTime - timeOffset;
-        var timeOffsetMinutes = timeLeft.Minutes.ToString();
-        var timeOffsetSeconds = timeLeft.Seconds.ToString();
+        var (timeOffsetMinutes, timeOffsetSeconds) = GetFormattedTimeLeft(timeOffset);
         if (timeOffset < _ghostRespawnTime)
         {
             SendChatMsg(ui.Player,
@@ -296,8 +295,7 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
 
         var timeOffset = _gameTiming.CurTime - deathTime;
         var timeLeft = _ghostRespawnTime - timeOffset;
-        var timeOffsetMinutes = timeLeft.Minutes.ToString();
-        var timeOffsetSeconds = timeLeft.Seconds.ToString();
+        var (timeOffsetMinutes, timeOffsetSeconds) = GetFormattedTimeLeft(timeOffset);
 
         if (timeOffset >= _ghostRespawnTime)
         {
@@ -356,5 +354,15 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
             _ghostSystem.SetTimeOfDeath(ghost, _deathTime[mindSession.UserId], ghostComponent);
             Dirty(ghost, ghostComponent);
         }
+    }
+
+    private (string minutes, string seconds) GetFormattedTimeLeft(TimeSpan timeOffset)
+    {
+        var timeLeft = _ghostRespawnTime - timeOffset;
+        if (timeLeft.TotalSeconds < 0)
+        {
+            return ("0", "0");
+        }
+        return (timeLeft.Minutes.ToString(), timeLeft.Seconds.ToString()); // god have mercy
     }
 }

--- a/Content.Server/Backmen/Ghost/GhostReJoinSystem.cs
+++ b/Content.Server/Backmen/Ghost/GhostReJoinSystem.cs
@@ -106,10 +106,13 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
             return;
         }
         var timeOffset = _gameTiming.CurTime - ent.Comp.TimeOfDeath;
+        var timeLeft = _ghostRespawnTime - timeOffset;
+        var timeOffsetMinutes = timeLeft.Minutes.ToString();
+        var timeOffsetSeconds = timeLeft.Seconds.ToString();
         if (timeOffset < _ghostRespawnTime)
         {
             SendChatMsg(ui.Player,
-                Loc.GetString("ghost-respawn-time-left", ("time", (_ghostRespawnTime - timeOffset).ToString()))
+                Loc.GetString("ghost-respawn-time-left", ("minutes", timeOffsetMinutes), ("seconds", timeOffsetSeconds))
             );
             return;
         }
@@ -150,10 +153,13 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
             return;
         }
         var timeOffset = _gameTiming.CurTime - ent.Comp.TimeOfDeath;
+        var timeLeft = _ghostRespawnTime - timeOffset;
+        var timeOffsetMinutes = timeLeft.Minutes.ToString();
+        var timeOffsetSeconds = timeLeft.Seconds.ToString();
         if (timeOffset < _ghostRespawnTime)
         {
             SendChatMsg(ui.Player,
-                Loc.GetString("ghost-respawn-time-left", ("time", (_ghostRespawnTime - timeOffset).ToString()))
+                Loc.GetString("ghost-respawn-time-left", ("minutes", timeOffsetMinutes), ("seconds", timeOffsetSeconds))
             );
             return;
         }
@@ -289,6 +295,9 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
         }
 
         var timeOffset = _gameTiming.CurTime - deathTime;
+        var timeLeft = _ghostRespawnTime - timeOffset;
+        var timeOffsetMinutes = timeLeft.Minutes.ToString();
+        var timeOffsetSeconds = timeLeft.Seconds.ToString();
 
         if (timeOffset >= _ghostRespawnTime)
         {
@@ -305,7 +314,7 @@ public sealed class GhostReJoinSystem : SharedGhostReJoinSystem
         }
 
         SendChatMsg(shell.Player,
-            Loc.GetString("ghost-respawn-time-left", ("time", (_ghostRespawnTime - timeOffset).ToString()))
+            Loc.GetString("ghost-respawn-time-left", ("minutes", timeOffsetMinutes), ("seconds", timeOffsetSeconds))
         );
     }
 

--- a/Resources/Locale/ru-RU/backmen/ghost/respawn.ftl
+++ b/Resources/Locale/ru-RU/backmen/ghost/respawn.ftl
@@ -1,5 +1,5 @@
 ﻿ghost-gui-return-to-round-button = Вернуться в раунд
-ghost-respawn-time-left = Осталось до возможности вернуться в раунд - { $time }.
+ghost-respawn-time-left = Осталось до возможности вернуться в раунд - { $minutes } минут, { $seconds } секунд.
 ghost-respawn-max-players = Функция недоступна, игроков на сервере должно быть меньше { $players }.
 ghost-respawn-window-request-button-timer = Принять ({ $time }сек.)
 ghost-respawn-window-request-button = Принять

--- a/Resources/Locale/ru-RU/backmen/ghost/respawn.ftl
+++ b/Resources/Locale/ru-RU/backmen/ghost/respawn.ftl
@@ -1,5 +1,13 @@
 ﻿ghost-gui-return-to-round-button = Вернуться в раунд
-ghost-respawn-time-left = Осталось до возможности вернуться в раунд - { $minutes } минут, { $seconds } секунд.
+ghost-respawn-time-left = Осталось до возможности вернуться в раунд - { $minutes } { $minutes ->
+    [one] минута
+    [few] минуты
+    *[other] минут
+}, { $seconds } { $seconds ->
+    [one] секунда
+    [few] секунды
+    *[other] секунд
+}.
 ghost-respawn-max-players = Функция недоступна, игроков на сервере должно быть меньше { $players }.
 ghost-respawn-window-request-button-timer = Принять ({ $time }сек.)
 ghost-respawn-window-request-button = Принять


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Изменил отображение в чате времени возврата в раунд (было "00:05:29.23853", стало "5 минут, 29 секунд")
## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Выглядит уютненько
## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->
Отсутствуют
## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->
Возможно позже. Иду делать исправление в факсах.
## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.
<!-- Вы должны понимать, что несоблюдение вышеуказанного может привести к закрытию вашего PR по усмотрению сопровождающего -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
Отсутствуют


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Улучшения**
	- Обновлена система отображения времени возрождения призрака
	- Добавлена более детальная информация о времени возрождения с разделением на минуты и секунды
	- Обновлена локализация для русскоязычных игроков с учетом грамматических правил для минут и секунд
<!-- end of auto-generated comment: release notes by coderabbit.ai -->