### PR TITLE
Add viewport height parameter

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -21,6 +21,11 @@
                 <CheckBox Name="ViewportStretchCheckBox" Text="{Loc 'ui-options-vp-stretch'}" />
                 <ui:OptionSlider Name="ViewportScaleSlider" Title="{Loc ui-options-vp-scale}" />
                 <ui:OptionSlider Name="ViewportWidthSlider" Title="{Loc ui-options-vp-width}" />
+
+                <!-- START RADIUM: GENOCIDE OF HEIGHT LINES -->
+                <ui:OptionSlider Name="ViewportHeightSlider" Title="{Loc ui-options-vp-height}" />
+                <!-- END RADIUM: GENOCIDE OF HEIGHT LINES -->
+
                 <CheckBox Name="IntegerScalingCheckBox"
                           Text="{Loc 'ui-options-vp-integer-scaling'}"
                           ToolTip="{Loc 'ui-options-vp-integer-scaling-tooltip'}" />

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -56,6 +56,16 @@ public sealed partial class GraphicsTab : Control
             (int)ViewportWidthSlider.Slider.MinValue,
             (int)ViewportWidthSlider.Slider.MaxValue);
 
+        //START RADIUM: GENOCIDE OF HEIGHT LINES
+
+        Control.AddOptionSlider(
+            CCVars.ViewportHeight,
+            ViewportHeightSlider,
+            (int)ViewportWidthSlider.Slider.MinValue,
+            (int)ViewportWidthSlider.Slider.MaxValue);
+
+        //END RADIUM: GENOCIDE OF HEIGHT LINES
+
         Control.AddOption(new OptionIntegerScaling(Control, _cfg, IntegerScalingCheckBox));
         Control.AddOptionCheckBox(CCVars.ViewportScaleRender, ViewportLowResCheckBox, invert: true);
         Control.AddOptionCheckBox(CCVars.ParallaxLowQuality, ParallaxLowQualityCheckBox);
@@ -65,6 +75,15 @@ public sealed partial class GraphicsTab : Control
 
         _cfg.OnValueChanged(CCVars.ViewportMinimumWidth, _ => UpdateViewportWidthRange());
         _cfg.OnValueChanged(CCVars.ViewportMaximumWidth, _ => UpdateViewportWidthRange());
+
+        //START RADIUM: GENOCIDE OF HEIGHT LINES
+
+        _cfg.OnValueChanged(CCVars.ViewportMinimumHeight, _ => UpdateViewportHeightRange());
+        _cfg.OnValueChanged(CCVars.ViewportMaximumHeight, _ => UpdateViewportHeightRange());
+
+        UpdateViewportHeightRange();
+
+        //END RADIUM: GENOCIDE OF HEIGHT LINES
 
         UpdateViewportWidthRange();
         UpdateViewportSettingsVisibility();
@@ -76,6 +95,8 @@ public sealed partial class GraphicsTab : Control
         IntegerScalingCheckBox.Visible = ViewportStretchCheckBox.Pressed;
         ViewportVerticalFitCheckBox.Visible = ViewportStretchCheckBox.Pressed;
         ViewportWidthSlider.Visible = !ViewportStretchCheckBox.Pressed || !ViewportVerticalFitCheckBox.Pressed;
+
+        ViewportHeightSlider.Visible = !ViewportStretchCheckBox.Pressed || !ViewportVerticalFitCheckBox.Pressed; //RADIUM: GENOCIDE OF HEIGHT LINES
     }
 
     private void UpdateViewportWidthRange()
@@ -87,6 +108,18 @@ public sealed partial class GraphicsTab : Control
         ViewportWidthSlider.Slider.MaxValue = max;
     }
 
+    //START RADIUM: GENOCIDE OF HEIGHT LINES
+
+    private void UpdateViewportHeightRange()
+    {
+        var min = _cfg.GetCVar(CCVars.ViewportMinimumHeight);
+        var max = _cfg.GetCVar(CCVars.ViewportMaximumHeight);
+
+        ViewportHeightSlider.Slider.MinValue = min;
+        ViewportHeightSlider.Slider.MaxValue = max;
+    }
+
+    //END RADIUM: GENOCIDE OF HEIGHT LINES
     private sealed class OptionLightingQuality : BaseOption
     {
         private readonly IConfigurationManager _cfg;

--- a/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
+++ b/Content.Client/UserInterface/Systems/Viewport/ViewportUIController.cs
@@ -29,6 +29,14 @@ public sealed class ViewportUIController : UIController
         _configurationManager.OnValueChanged(CCVars.ViewportWidth, _ => UpdateViewportRatio());
         _configurationManager.OnValueChanged(CCVars.ViewportVerticalFit, _ => UpdateViewportRatio());
 
+        //START RADIUM: GENOCIDE OF HEIGHT LINES
+
+        _configurationManager.OnValueChanged(CCVars.ViewportMinimumWidth, _ => UpdateViewportRatio());
+        _configurationManager.OnValueChanged(CCVars.ViewportMaximumWidth, _ => UpdateViewportRatio());
+        _configurationManager.OnValueChanged(CCVars.ViewportHeight, _ => UpdateViewportRatio());
+
+        //END RADIUM: GENOCIDE OF HEIGHT LINES
+
         var gameplayStateLoad = UIManager.GetUIController<GameplayStateLoadController>();
         gameplayStateLoad.OnScreenLoad += OnScreenLoad;
     }
@@ -45,21 +53,41 @@ public sealed class ViewportUIController : UIController
             return;
         }
 
-        var min = _configurationManager.GetCVar(CCVars.ViewportMinimumWidth);
-        var max = _configurationManager.GetCVar(CCVars.ViewportMaximumWidth);
+        var minWidth = _configurationManager.GetCVar(CCVars.ViewportMinimumWidth);
+        var maxWidth = _configurationManager.GetCVar(CCVars.ViewportMaximumWidth);
         var width = _configurationManager.GetCVar(CCVars.ViewportWidth);
-        var verticalfit = _configurationManager.GetCVar(CCVars.ViewportVerticalFit) && _configurationManager.GetCVar(CCVars.ViewportStretch);
+
+        //START RADIUM: GENOCIDE OF HEIGHT LINES
+
+        var minHeight = _configurationManager.GetCVar(CCVars.ViewportMinimumHeight);
+        var maxHeight = _configurationManager.GetCVar(CCVars.ViewportMaximumHeight);
+        var height = _configurationManager.GetCVar(CCVars.ViewportHeight);
+
+        //END RADIUM: GENOCIDE OF HEIGHT LINES
+
+        var verticalfit = _configurationManager.GetCVar(CCVars.ViewportVerticalFit) &&
+                          _configurationManager.GetCVar(CCVars.ViewportStretch);
 
         if (verticalfit)
         {
-            width = max;
+            width = maxWidth;
+            height = maxHeight; //RADIUM: GENOCIDE OF HEIGHT LINES
         }
-        else if (width < min || width > max)
+        else
         {
-            width = CCVars.ViewportWidth.DefaultValue;
+            if (width < minWidth || width > maxWidth)
+            {
+                width = CCVars.ViewportWidth.DefaultValue;
+            }
+
+            if (height < minHeight || height > maxHeight)
+            {
+                height = CCVars.ViewportHeight.DefaultValue; //RADIUM: GENOCIDE OF HEIGHT LINES
+            }
         }
 
-        Viewport.Viewport.ViewportSize = (EyeManager.PixelsPerMeter * width, EyeManager.PixelsPerMeter * ViewportHeight);
+        Viewport.Viewport.ViewportSize =
+            (EyeManager.PixelsPerMeter * width, EyeManager.PixelsPerMeter * height); //RADIUM: GENOCIDE OF HEIGHT LINES
         Viewport.UpdateCfg();
     }
 
@@ -104,6 +132,7 @@ public sealed class ViewportUIController : UIController
 
         // Currently, this shouldn't happen. This likely happened because the main eye was set to null. When this
         // does happen it can create hard to troubleshoot bugs, so lets print some helpful warnings:
-        Logger.Warning($"Main viewport's eye is in nullspace (main eye is null?). Attached entity: {_entMan.ToPrettyString(ent.Value)}. Entity has eye comp: {eye != null}");
+        Logger.Warning(
+            $"Main viewport's eye is in nullspace (main eye is null?). Attached entity: {_entMan.ToPrettyString(ent.Value)}. Entity has eye comp: {eye != null}");
     }
 }

--- a/Content.Shared/CCVar/CCVars.Viewport.cs
+++ b/Content.Shared/CCVar/CCVars.Viewport.cs
@@ -5,7 +5,7 @@ namespace Content.Shared.CCVar;
 public sealed partial class CCVars
 {
     public static readonly CVarDef<bool> ViewportStretch =
-        CVarDef.Create("viewport.stretch", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("viewport.stretch", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     public static readonly CVarDef<int> ViewportFixedScaleFactor =
         CVarDef.Create("viewport.fixed_scale_factor", 2, CVar.CLIENTONLY | CVar.ARCHIVE);
@@ -23,10 +23,10 @@ public sealed partial class CCVars
         CVarDef.Create("viewport.minimum_width", 15, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<int> ViewportMaximumWidth =
-        CVarDef.Create("viewport.maximum_width", 21, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("viewport.maximum_width", 39, CVar.REPLICATED | CVar.SERVER); //RADIUM: DEF VALUE CHANGED
 
     public static readonly CVarDef<int> ViewportWidth =
-        CVarDef.Create("viewport.width", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("viewport.width", 39, CVar.CLIENTONLY | CVar.ARCHIVE); //RADIUM: DEF VALUE CHANGED
 
     public static readonly CVarDef<bool> ViewportVerticalFit =
         CVarDef.Create("viewport.vertical_fit", true, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Content.Shared/Radium/CCVar/CCVars.Viewport.cs
+++ b/Content.Shared/Radium/CCVar/CCVars.Viewport.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<int> ViewportMaximumHeight =
+        CVarDef.Create("viewport.maximum_height", 21, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<int> ViewportMinimumHeight =
+        CVarDef.Create("viewport.minimum_height", 15, CVar.REPLICATED | CVar.SERVER);
+
+    public static readonly CVarDef<int> ViewportHeight =
+        CVarDef.Create("viewport.height", 21, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Resources/Locale/ru-RU/radium/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/ru-RU/radium/escape-menu/ui/options-menu.ftl
@@ -1,0 +1,1 @@
+ui-options-vp-height = Высота окна игры:


### PR DESCRIPTION
Add viewport height parameter that allow normal screen scaling.
Probably shouldn't cause any troubles.
Default viewport values raised, however scaling has 2x modifier that can be changed from options. Yep, that's a legal 0.5 zoom, questions? 
Don't care about cheaters or ultra-robust RDMers, they already suck, won't hurt.
No more black lines ever (at least with 1920x1080 screen)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Добавлен новый элемент управления для настройки высоты игрового окна в графическом меню.
  - Расширена логика регулирования размеров окна: теперь доступны параметры минимальной и максимальной высоты, а также обновлены параметры по умолчанию для ширины и режима растяжения.

- **Documentation**
  - Добавлена русская локализация для подписи опции высоты игрового окна.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->