### PR TITLE
Extend flavor text + fix title

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -22,13 +22,6 @@
                               Name="HeaderContainer"
                               Access="Public"
                               SeparationOverride="4">
-                    <Label Margin="8 0 0 0" StyleClasses="LabelHeadingBigger"
-                           VAlign="Center"
-                           HorizontalExpand="True"
-                           HorizontalAlignment="Left"
-                           FontColorOverride="{x:Static style:StyleNano.NanoGold}"
-                           FontColorShadowOverride="{x:Static style:StyleNano.DisabledFore}"
-                           Text="{Loc 'ui-lobby-title'}" />
                     <Label Name="ServerName" Access="Public"
                            StyleClasses="LabelHeadingBigger"
                            VAlign="Center"

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -31,7 +31,7 @@ namespace Content.Shared.Preferences
 
         public const int MaxNameLength = 32;
         public const int MaxLoadoutNameLength = 32;
-        public const int MaxDescLength = 512;
+        public const int MaxDescLength = 4096;
 
         /// <summary>
         /// Job preferences for initial spawn.


### PR DESCRIPTION
<!-- Рекомендации: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Описание PR
<!-- Что вы изменили? -->
Увеличивает максимальную длину flavor текста до 4096 символов.
Удаляет лишнее название лобби в меню.

## Почему / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения или issue. -->
Позволяет писать более ёмкие описания (запрос).